### PR TITLE
php metricsの導入

### DIFF
--- a/.github/workflows/phpmetrics.yml
+++ b/.github/workflows/phpmetrics.yml
@@ -82,7 +82,7 @@ jobs:
           DB_PASSWORD: password
 
       - name: Run tests with coverage
-        run: vendor/bin/pest --coverage-html coverage.html
+        run: vendor/bin/pest --log-junit junit.xml --coverage-clover coverage.xml
         continue-on-error: true
         env:
           DB_CONNECTION: mysql
@@ -97,7 +97,7 @@ jobs:
           mkdir -p public/metrics
           vendor/bin/phpmetrics --report-html=public/metrics \
             --report-violations=public/metrics/violations.xml \
-            --junit=coverage.html \
+            --junit=junit.xml \
             --git \
             --exclude=vendor,node_modules,tests,database,bootstrap,storage,public \
             app/

--- a/.github/workflows/phpmetrics.yml
+++ b/.github/workflows/phpmetrics.yml
@@ -37,10 +37,9 @@ jobs:
             ${{ runner.os }}-php-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
-
-      - name: Composer update
-        run: composer update
+        run: |
+          composer install --prefer-dist --no-progress --no-suggest
+          composer update
 
       - name: Install PHPMetrics
         run: composer require --dev phpmetrics/phpmetrics

--- a/.github/workflows/phpmetrics.yml
+++ b/.github/workflows/phpmetrics.yml
@@ -95,8 +95,6 @@ jobs:
       - name: Generate PHPMetrics report
         run: |
           mkdir -p public/metrics
-          # Debug: Check if JUnit and coverage files exist
-          ls -la junit.xml coverage.xml || true
           vendor/bin/phpmetrics --report-html=public/metrics \
             --report-violations=public/metrics/violations.xml \
             --junit=junit.xml \

--- a/.github/workflows/phpmetrics.yml
+++ b/.github/workflows/phpmetrics.yml
@@ -2,7 +2,7 @@ name: PHP Metrics Report
 
 on:
   push:
-    branches: [ main, test-phpmetrics ]  # 検証ブランチを追加
+    branches: [main, test-phpmetrics] # 検証ブランチを追加
   workflow_dispatch:
 
 permissions:
@@ -11,7 +11,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: 'pages'
   cancel-in-progress: false
 
 jobs:
@@ -38,6 +38,9 @@ jobs:
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Composer update
+        run: composer update
 
       - name: Install PHPMetrics
         run: composer require --dev phpmetrics/phpmetrics

--- a/.github/workflows/phpmetrics.yml
+++ b/.github/workflows/phpmetrics.yml
@@ -17,6 +17,18 @@ concurrency:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.4
+        # TODO: Use secrets for password
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: laravel_test
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -44,9 +56,29 @@ jobs:
       - name: Install PHPMetrics
         run: composer require --dev phpmetrics/phpmetrics
 
+      - name: Setup Laravel application
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+          php artisan migrate --force
+        env:
+          DB_CONNECTION: mysql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_DATABASE: laravel_test
+          DB_USERNAME: root
+          DB_PASSWORD: password
+
       - name: Run tests with coverage
         run: vendor/bin/pest --coverage-clover coverage.xml
         continue-on-error: true
+        env:
+          DB_CONNECTION: mysql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_DATABASE: laravel_test
+          DB_USERNAME: root
+          DB_PASSWORD: password
 
       - name: Generate PHPMetrics report
         run: |

--- a/.github/workflows/phpmetrics.yml
+++ b/.github/workflows/phpmetrics.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer install --prefer-dist --no-progress --no-suggest
-          composer update
+          composer update --prefer-dist --no-progress --no-interaction
+          composer install --prefer-dist --no-progress --no-interaction
 
       - name: Install PHPMetrics
         run: composer require --dev phpmetrics/phpmetrics

--- a/.github/workflows/phpmetrics.yml
+++ b/.github/workflows/phpmetrics.yml
@@ -2,7 +2,7 @@ name: PHP Metrics Report
 
 on:
   push:
-    branches: [main, test-phpmetrics] # 検証ブランチを追加
+    branches: ['main']
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/phpmetrics.yml
+++ b/.github/workflows/phpmetrics.yml
@@ -95,6 +95,8 @@ jobs:
       - name: Generate PHPMetrics report
         run: |
           mkdir -p public/metrics
+          # Debug: Check if JUnit and coverage files exist
+          ls -la junit.xml coverage.xml || true
           vendor/bin/phpmetrics --report-html=public/metrics \
             --report-violations=public/metrics/violations.xml \
             --junit=junit.xml \

--- a/.github/workflows/phpmetrics.yml
+++ b/.github/workflows/phpmetrics.yml
@@ -37,8 +37,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
-          extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, dom, filter, json, phar, tokenizer
-          coverage: xdebug
+          extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, dom, filter, json, phar, tokenizer, pcov
+          coverage: pcov
 
       - name: Cache Composer dependencies
         uses: actions/cache@v4

--- a/.github/workflows/phpmetrics.yml
+++ b/.github/workflows/phpmetrics.yml
@@ -56,6 +56,18 @@ jobs:
       - name: Install PHPMetrics
         run: composer require --dev phpmetrics/phpmetrics
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build frontend assets
+        run: npm run build
+
       - name: Setup Laravel application
         run: |
           cp .env.example .env

--- a/.github/workflows/phpmetrics.yml
+++ b/.github/workflows/phpmetrics.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, dom, filter, json, phar, tokenizer
           coverage: xdebug
 

--- a/.github/workflows/phpmetrics.yml
+++ b/.github/workflows/phpmetrics.yml
@@ -82,7 +82,7 @@ jobs:
           DB_PASSWORD: password
 
       - name: Run tests with coverage
-        run: vendor/bin/pest --coverage-clover coverage.xml
+        run: vendor/bin/pest --coverage-html coverage.html
         continue-on-error: true
         env:
           DB_CONNECTION: mysql
@@ -97,7 +97,7 @@ jobs:
           mkdir -p public/metrics
           vendor/bin/phpmetrics --report-html=public/metrics \
             --report-violations=public/metrics/violations.xml \
-            --junit=coverage.xml \
+            --junit=coverage.html \
             --git \
             --exclude=vendor,node_modules,tests,database,bootstrap,storage,public \
             app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd \
     && pecl install yaml \
     && docker-php-ext-enable yaml \
+    && pecl install pcov \
+    && docker-php-ext-enable pcov \
     && pecl clear-cache
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
- **php metrics用のworkflowファイルを追加**
- **push対象のブランチにテストブランチを追加**
- **composer updateを実行するように修正**
- **composer install直後にupdateを実行するように修正**
- **install前にupdateを実行するように修正**
- **phpのバージョンを8.4に変更**
- **mysqlのセットアップを追加**
- **nodeセットアップ処理を追加**
- **test coverageの出力をhtmlに変更**
- **coverageレポートの出力形式を.xmlに変更**
- **コンテナでのテストカバレッジ測定を有効化**
- **github actionsでpcovを使用するように変更**
- **テストカバレッジのデバッグ**
- **デバッグログの削除**
- **ワークフローの実行タイミングをmainへのマージ時のみに修正**
